### PR TITLE
Add permissions checks for the HTTP API

### DIFF
--- a/api/auth/http.go
+++ b/api/auth/http.go
@@ -5,10 +5,31 @@ import (
 
 	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
+	"github.com/go-chi/chi/v5"
 )
 
 // Middleware creates an HTTP middleware for validating JWT tokens
-func Middleware(validator *validator.Validator) func(next http.Handler) http.Handler {
+func Middleware(validator *validator.Validator, permission Permission) func(next http.Handler) http.Handler {
 	middleware := jwtmiddleware.New(validator.ValidateToken)
-	return middleware.CheckJWT
+	return chi.Chain(middleware.CheckJWT, permissionsValidator(permission)).Handler
+}
+
+// permissionsValidator checks if the validated JWT has the requested permission
+func permissionsValidator(permission Permission) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Get the custom claims
+			claims := r.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
+			customClaims := claims.CustomClaims.(*CustomClaims)
+
+			// Check the permission
+			permissions := NewPermissions(customClaims.Permissions)
+			if permissions.Has(permission) {
+				next.ServeHTTP(w, r)
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"message":"Improper permissions."}`))
+			}
+		})
+	}
 }

--- a/api/handlers/animations/animations.go
+++ b/api/handlers/animations/animations.go
@@ -17,14 +17,16 @@ import (
 
 // Router registers all the methods for handling animations
 func Router(v *validator.Validator) func(r chi.Router) {
+	m := auth.Middleware(v, auth.PermissionEditAnimations)
+
 	return func(r chi.Router) {
 		r.Get("/", list)
-		r.With(auth.Middleware(v)).Post("/", create)
+		r.With(m).Post("/", create)
 
 		r.Route("/{id}", func(r chi.Router) {
 			r.Get("/", read)
-			r.With(auth.Middleware(v)).Patch("/", update)
-			r.With(auth.Middleware(v)).Delete("/", remove)
+			r.With(m).Patch("/", update)
+			r.With(m).Delete("/", remove)
 		})
 	}
 }

--- a/api/handlers/presets/presets.go
+++ b/api/handlers/presets/presets.go
@@ -16,14 +16,16 @@ import (
 
 // Router registers all the methods for handling presets
 func Router(v *validator.Validator) func(r chi.Router) {
+	m := auth.Middleware(v, auth.PermissionEditPresets)
+
 	return func(r chi.Router) {
 		r.Get("/", list)
-		r.With(auth.Middleware(v)).Post("/", create)
+		r.With(m).Post("/", create)
 
 		r.Route("/{id}", func(r chi.Router) {
 			r.Get("/", read)
-			r.With(auth.Middleware(v)).Patch("/", update)
-			r.With(auth.Middleware(v)).Delete("/", remove)
+			r.With(m).Patch("/", update)
+			r.With(m).Delete("/", remove)
 		})
 	}
 }

--- a/api/handlers/schedules/schedules.go
+++ b/api/handlers/schedules/schedules.go
@@ -17,16 +17,18 @@ import (
 
 // Router registers all the methods for handling schedules
 func Router(v *validator.Validator) func(r chi.Router) {
+	m := auth.Middleware(v, auth.PermissionEditSchedules)
+
 	return func(r chi.Router) {
 		r.Get("/", list)
-		r.With(auth.Middleware(v)).Post("/", create)
+		r.With(m).Post("/", create)
 
 		r.Route("/{id}", func(r chi.Router) {
 			r.Get("/", read)
-			r.With(auth.Middleware(v)).Patch("/", update)
-			r.With(auth.Middleware(v)).Delete("/", remove)
+			r.With(m).Patch("/", update)
+			r.With(m).Delete("/", remove)
 
-			r.With(auth.Middleware(v)).Put("/toggle", toggle)
+			r.With(m).Put("/toggle", toggle)
 		})
 	}
 }


### PR DESCRIPTION
Resolves: #7 

Assigns permissions to any endpoints that modify data and checks that they exist in the requester's JWT.